### PR TITLE
Z-index för toggle-sidebar saknades

### DIFF
--- a/css/readtheorg.css
+++ b/css/readtheorg.css
@@ -444,18 +444,18 @@ table tr:nth-child(2n) td{
     }
 
     #toggle-sidebar h2 {
-		background-color:#2980B9;
-		width:100%;
-		height:50px;
-		left:0;
-		top:0;
+        background-color: #2980B9;
+        width: 100%;
+        height: 50px;
+        left: 0;
+        top: 0;
         color: white;
         font-size: 100%;
         line-height: 50px;
-		position:fixed;
+        position: fixed;
         margin: 0;
         padding: 0;
-		opacity:0.7;
+        opacity: 0.7;
     }
 
     #table-of-contents .close-sidebar {

--- a/css/readtheorg.css
+++ b/css/readtheorg.css
@@ -456,6 +456,7 @@ table tr:nth-child(2n) td{
         margin: 0;
         padding: 0;
         opacity: 0.7;
+        z-index: 100;
     }
 
     #table-of-contents .close-sidebar {


### PR DESCRIPTION
Headern hamnar under kodblock och tables då skärmstorleken är mindre än 768px.