### PR TITLE
Show inactive sidebar subsections

### DIFF
--- a/css/readtheorg.css
+++ b/css/readtheorg.css
@@ -834,7 +834,7 @@ hr{
     margin-bottom:0.809em}
 
 ul.nav li a:not(.active) + ul li {
-    display: none;
+    display: block;
 }
 
 ul.nav li a:not(.active) + ul li a:not(.active) + ul li {


### PR DESCRIPTION
Borde visa alla sektioner i navbaren nu, ser ut så här:

![Exempel på navbar](https://blob.novium.pw/shrx/2019/04/firefox_OhX9rKS8e0.png)

